### PR TITLE
Pass AccountType to gateway

### DIFF
--- a/src/Message/Form/AuthorizeRequest.php
+++ b/src/Message/Form/AuthorizeRequest.php
@@ -17,6 +17,7 @@ class AuthorizeRequest extends DirectAuthorizeRequest
      * The DeliveryState is conditionally mandatory.
      */
     protected $validFields = [
+        'AccountType' => false,
         'VendorTxCode' => true,
         'Amount' => true,
         'Currency' => true,


### PR DESCRIPTION
Fixes using AccountType being sent to gateway when it's been specifically set.

Currently when trying to set the AccountType, the parameter gets removed removed.